### PR TITLE
add connected_team_ids

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -30,6 +30,7 @@ type Conversation struct {
 	NumMembers         int      `json:"num_members"`
 	Priority           float64  `json:"priority"`
 	User               string   `json:"user"`
+	ConnectedTeamIDs   []string `json:"connected_team_ids,omitempty"`
 
 	// TODO support pending_shared
 	// TODO support previous_names


### PR DESCRIPTION
Adding `connected_team_ids` to `Conversation` struct.

When conversation.info is called with an external shared channel, the response comes with a list of team_ids that are connected to the channel.

![image](https://github.com/zFlabmonsta/slack/assets/33224337/18a078da-4323-424f-aacd-d09890f441a2)

